### PR TITLE
Switch backend to GHCR terminal image

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This guide assumes a fresh **Ubuntu 24.04 LTS VM** with SSH access and your proj
     # Crucial: Log out/in, then run ./deploy_prep.sh again to complete.
     ```
 
-2.  **Perform Full Project Deployment:** Copies frontend, builds Docker images, starts backend.
+2.  **Perform Full Project Deployment:** Copies frontend, pulls the latest container images, and starts the backend.
 
     ```bash
     chmod +x deploy.sh

--- a/deploy.sh
+++ b/deploy.sh
@@ -12,7 +12,7 @@ BACKEND_IMAGE_NAME="web-terminal-backend-app"
 BACKEND_CONTAINER_NAME="web-terminal-server-instance"
 
 TERMINAL_CONTAINER_DIR="$PROJECT_ROOT/container"
-TERMINAL_IMAGE_NAME="terminal-container"
+TERMINAL_IMAGE_NAME="ghcr.io/bieggerm/projectchimera.xyz/terminal-container:latest"
 
 echo "--- Starting Project Chimera Full Deployment ---"
 echo "Project Root: $PROJECT_ROOT"
@@ -67,16 +67,13 @@ echo "Backend container '$BACKEND_CONTAINER_NAME' started successfully on port 3
 echo "--- Backend Container Deployment Complete ---"
 echo "------------------------------------------------"
 
-echo "--- Building Terminal Container Image ---"
+echo "--- Pulling Terminal Container Image ---"
 
-echo "Navigating to terminal container directory: $TERMINAL_CONTAINER_DIR"
-cd "$TERMINAL_CONTAINER_DIR"
+echo "Pulling Docker image: $TERMINAL_IMAGE_NAME"
+docker pull "$TERMINAL_IMAGE_NAME"
+echo "Docker image '$TERMINAL_IMAGE_NAME' pulled successfully."
 
-echo "Building Docker image: $TERMINAL_IMAGE_NAME"
-docker build -t "$TERMINAL_IMAGE_NAME" .
-echo "Docker image '$TERMINAL_IMAGE_NAME' built successfully."
-
-echo "--- Terminal Container Image Build Complete ---"
+echo "--- Terminal Container Image Pull Complete ---"
 echo "------------------------------------------------"
 
 echo "--- Restarting Nginx service ---"


### PR DESCRIPTION
## Summary
- pull the prebuilt terminal container from GHCR by default
- update deploy script to pull the container instead of building locally
- clarify deployment docs about pulling images

## Testing
- `node -c backend/server.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685321d6c80c83278bbfcd48fe0061a8