### PR TITLE
Switch WebSocket URL based on environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,13 @@ This guide assumes a fresh **Ubuntu 24.04 LTS VM** with SSH access and your proj
     # Crucial: Log out/in, then run ./deploy_prep.sh again to complete.
     ```
 
-2.  **Perform Full Project Deployment:** Copies frontend, pulls the latest container images, and starts the backend.
+2.  **Perform Full Project Deployment:** Copies frontend, writes the production WebSocket URL, pulls the latest container images, and starts the backend.
 
     ```bash
     chmod +x deploy.sh
-    # Set your domain name as an environment variable before running
-    export DOMAIN_NAME="projectchimera.xyz" 
+    # Set your domain name as an environment variable before running.
+    # deploy.sh uses this to generate frontend/js/config.js
+    export DOMAIN_NAME="projectchimera.xyz"
     sudo ./deploy.sh
     ```
 
@@ -105,6 +106,7 @@ Navigate to `https://projectchimera.xyz/` in your web browser. Interact with the
 * **Terminal Environment:** Adjust `container/Dockerfile` and `container/entrypoint.sh`.
 * **MOTD:** Edit `container/your_motd_file.txt`.
 * **UI/Animations:** Modify `frontend/js/animations.js`, `frontend/main.js`, `frontend/index.html` CSS.
+* **WebSocket URL:** Update `frontend/js/config.js` for local vs production environments (automatically overwritten by `deploy.sh`).
 
 ---
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -29,6 +29,8 @@ sudo mkdir -p "$FRONTEND_DEST_DIR"
 echo "Copying files from $FRONTEND_SOURCE_DIR to $FRONTEND_DEST_DIR..."
 sudo rsync -av --delete "$FRONTEND_SOURCE_DIR/" "$FRONTEND_DEST_DIR/"
 echo "Frontend files copied."
+echo "Writing WebSocket configuration..."
+sudo bash -c "echo \"window.WEBSOCKET_URL = 'wss://$DOMAIN_NAME/terminal';\" > \"$FRONTEND_DEST_DIR/js/config.js\""
 
 echo "Setting ownership to $NGINX_USER:$NGINX_USER for $FRONTEND_DEST_DIR..."
 sudo chown -R "$NGINX_USER":"$NGINX_USER" "$FRONTEND_DEST_DIR"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -191,6 +191,7 @@
             to { text-shadow: 0 0 20px rgba(158, 206, 106, 0.8), 0 0 30px rgba(158, 206, 106, 0.3); }
         }
     </style>
+    <script src="js/config.js"></script>
     <script src="js/main.js" defer></script>
     <script src="js/animations.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.js"></script>

--- a/frontend/js/config.js
+++ b/frontend/js/config.js
@@ -1,0 +1,4 @@
+// config.js
+// This value is used by main.js to establish the WebSocket connection.
+// Update as needed for your environment.
+window.WEBSOCKET_URL = "ws://192.168.0.99/terminal";

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -37,7 +37,9 @@ term.open(termContainer);
 fitAddon.fit();
 window.addEventListener("resize", () => fitAddon.fit());
 
-const websocketUrl = `ws://192.168.0.99:3000/terminal`;
+// The WebSocket URL is provided via `window.WEBSOCKET_URL` from config.js.
+// Fallback to the development server if the variable is missing.
+const websocketUrl = window.WEBSOCKET_URL || "ws://192.168.0.99/terminal";
 const ws = new WebSocket(websocketUrl);
 
 ws.onopen = () => {


### PR DESCRIPTION
## Summary
- configure WebSocket URL via new `frontend/js/config.js`
- load that config in `index.html`
- use the configured URL in `main.js`
- write the production WebSocket URL during `deploy.sh`
- document the new configuration in `README.md`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6853233a698083278343abf01180fa0e